### PR TITLE
Create matplotlib-formatting.txt

### DIFF
--- a/matplotlib-formatting.txt
+++ b/matplotlib-formatting.txt
@@ -1,0 +1,47 @@
+# ======== MATPLOTLIB FORMATTING ======== #
+# Written in Python comment format if you want to paste into .py
+# files for reference.
+# ======================================= #
+
+''' Available colours: 
+	'b' blue, 'g' green, 'r' red, # 'c' cyan, # 'm' magenta, # 'y' yellow, # 'k' black, # 'w' white '''
+
+''' Available markers:
+	'.' 	point marker
+	',' 	pixel marker
+	'o' 	circle marker
+	'v' 	triangle_down marker
+	'^' 	triangle_up marker
+	'<' 	triangle_left marker
+	'>' 	triangle_right marker
+	'1' 	tri_down marker
+	'2' 	tri_up marker
+	'3' 	tri_left marker
+	'4' 	tri_right marker
+	's' 	square marker
+	'p' 	pentagon marker
+	'*' 	star marker
+	'h' 	hexagon1 marker
+	'H' 	hexagon2 marker
+	'+' 	plus marker
+	'x' 	x marker
+	'D' 	diamond marker
+	'd' 	thin_diamond marker
+	'|' 	vline marker
+	'_' 	hline marker
+'''
+
+''' Available line styles:
+	'-' 	solid line style
+	'--' 	dashed line style
+	'-.' 	dash-dot line style
+	':' 	dotted line style
+'''
+
+''' Example format strings:
+	'b'    # blue markers with default shape
+	'or'   # red circles
+	'-g'   # green solid line
+	'--'   # dashed line with default color
+	'^k:'  # black triangle_up markers connected by a dotted line
+'''


### PR DESCRIPTION
Thi is a text file with matplotlib formatting syntax.  I've added them in a format that can be simply pasted into Python files should you want to safely paste them in for reference.